### PR TITLE
Create Main Boats section, Style Boats, Login and Signup

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import {
+  BrowserRouter as Router, Routes, Route, Navigate,
+} from 'react-router-dom';
 import Layout from './components/Layout';
 import Boats from './components/pages/Boats';
 import BoatDetails from './components/pages/BoatDetails';
@@ -11,7 +13,7 @@ const App = () => (
   <Router>
     <Routes>
       <Route path="/" element={<Layout />}>
-        <Route index element={<Boats />} />
+        <Route index element={<Navigate to="/boats" />} />
         <Route path="login" element={<Login />} />
         <Route path="signup" element={<Signup />} />
         <Route path="boats" element={<Boats />} />

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -100,7 +100,7 @@ const Header = () => {
         </nav>
 
         <div>
-          <div className="flex justify-center space-x-8 py-6">
+          <div className="flex justify-center space-x-4 py-6">
             <a href="https://twitter.com" target="_blank" rel="noopener noreferrer" aria-label="Twitter">
               <FaTwitter />
             </a>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -45,7 +45,7 @@ const Header = () => {
             <h2 className="font-bold text-2xl mr-10">Boat Logo</h2>
           </div>
 
-          <ul className="flex flex-col text-2xl font-bold items-center mb-[150px]">
+          <ul className="flex flex-col text-xl font-bold items-center mb-[150px] uppercase">
             {links.map(({ path, text }) => (
               <li key={text} className="w-full">
                 <NavLink to={path} onClick={() => setIsOpen(false)} className="w-full block text-center py-4">
@@ -82,8 +82,8 @@ const Header = () => {
       <section className="hidden lg:flex flex-col justify-between h-full pb-6">
         <h2 className="font-bold text-2xl text-center mt-10">Boat Logo</h2>
 
-        <nav className="mb-[200px]">
-          <ul className="hidden lg:flex flex-col text-2xl m-0 font-bold">
+        <nav className="mb-[200px] uppercase">
+          <ul className="hidden lg:flex flex-col text-xl m-0 font-bold">
             {links.map(({ path, text }) => (
               <li key={text}>
                 <NavLink to={path} className="block text-center py-3">

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -29,7 +29,7 @@ const Layout = () => {
         <Header />
       </header>
 
-      <main className="lg:ml-[20%]">
+      <main className="lg:ml-[20%] lg:flex lg:items-center lg:h-screen">
         {user && <h3 className="text-blue-600 font-bold text-xl">{`Welcome, ${user.name}!`}</h3>}
         {message && <p className="text-purple-500">{message}</p>}
         <Outlet />

--- a/src/components/pages/Boats.jsx
+++ b/src/components/pages/Boats.jsx
@@ -1,7 +1,67 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { Link } from 'react-router-dom';
+import { FaTwitter, FaFacebook, FaGooglePlus } from 'react-icons/fa';
+import { fetchBoats, selectAllBoats } from '../../redux/boats/boatsSlice';
 
-const Boats = () => (
-  <div>All Boats</div>
-);
+const Boats = () => {
+  const dispatch = useDispatch();
+  const boats = useSelector(selectAllBoats);
+  const [currentPage, setCurrentPage] = useState(1);
+  const itemsPerPage = 3;
+
+  useEffect(() => {
+    dispatch(fetchBoats());
+  }, [dispatch]);
+
+  const indexOfLastItem = currentPage * itemsPerPage;
+  const indexOfFirstItem = indexOfLastItem - itemsPerPage;
+  const currentItems = Array.isArray(boats) ? boats.slice(indexOfFirstItem, indexOfLastItem) : [];
+
+  const paginate = (pageNumber) => setCurrentPage(pageNumber);
+
+  return (
+    <section className="mx-4 my-6 flex flex-col justify-center items-center">
+      <h2 className="text-center text-2xl font-bold my-4">All Boat Models</h2>
+
+      <h4 className="text-center mb-4">Please select one to Reserve</h4>
+
+      <div className="flex flex-col gap-10 p-2">
+        {currentItems.map((boat) => (
+          <div key={boat.id}>
+            <Link to={`/boats/${boat.id}`} className="block">
+              <img src={boat.picture} alt={boat.name} className="object-contain rounded-md" />
+            </Link>
+            <h3 className="text-center text-xl font-bold my-4">{boat.name}</h3>
+            <p className="text-center mb-4">{boat.description}</p>
+            <div className="flex justify-center gap-10">
+              <FaTwitter />
+              <FaFacebook />
+              <FaGooglePlus />
+            </div>
+          </div>
+        ))}
+        <div className="flex justify-between">
+          <button
+            onClick={() => paginate(currentPage - 1)}
+            disabled={currentPage === 1}
+            type="button"
+            className="font-bold text-2xl bg-lime-500 pl-10 pr-4 py-2 rounded-r-3xl text-white"
+          >
+            {'<'}
+          </button>
+          <button
+            onClick={() => paginate(currentPage + 1)}
+            disabled={currentPage === Math.ceil(boats.length / itemsPerPage)}
+            type="button"
+            className="font-bold text-2xl bg-lime-500 pr-10 pl-4 py-2 rounded-l-3xl text-white"
+          >
+            {'>'}
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+};
 
 export default Boats;

--- a/src/components/pages/Boats.jsx
+++ b/src/components/pages/Boats.jsx
@@ -21,19 +21,31 @@ const Boats = () => {
   const paginate = (pageNumber) => setCurrentPage(pageNumber);
 
   return (
-    <section className="mx-4 my-6 flex flex-col justify-center items-center">
-      <h2 className="text-center text-2xl font-bold my-4">All Boat Models</h2>
+    <section className="mx-4 my-6 flex flex-col items-center lg:mb-20">
+      <h2 className="text-center text-2xl font-black my-4 lg:text-3xl lg:my-10 uppercase">All Boat Models</h2>
 
-      <h4 className="text-center mb-4">Please select one to Reserve</h4>
+      <h4 className="text-center">Please select one to Reserve</h4>
 
-      <div className="flex flex-col gap-10 p-2">
+      <p className="text-gray-300 my-6">********************</p>
+
+      <div className="flex flex-col gap-10 p-2 lg:grid lg:grid-cols-11">
+        <button
+          onClick={() => paginate(currentPage - 1)}
+          disabled={currentPage === 1}
+          type="button"
+          className="font-bold text-2xl bg-lime-500 pl-10 pr-4 py-2 rounded-r-3xl text-white hidden lg:block lg:h-14 lg:self-center lg:col-span-1"
+        >
+          {'<'}
+        </button>
+
         {currentItems.map((boat) => (
-          <div key={boat.id}>
+          <div key={boat.id} className="lg:col-span-3">
             <Link to={`/boats/${boat.id}`} className="block">
               <img src={boat.picture} alt={boat.name} className="object-contain rounded-md" />
             </Link>
             <h3 className="text-center text-xl font-bold my-4">{boat.name}</h3>
-            <p className="text-center mb-4">{boat.description}</p>
+            <p className="text-gray-300 mb-4 text-center">********************</p>
+            <p className="text-center mb-6">{boat.description}</p>
             <div className="flex justify-center gap-10">
               <FaTwitter />
               <FaFacebook />
@@ -41,7 +53,16 @@ const Boats = () => {
             </div>
           </div>
         ))}
-        <div className="flex justify-between">
+
+        <button
+          onClick={() => paginate(currentPage + 1)}
+          disabled={currentPage === Math.ceil(boats.length / itemsPerPage)}
+          type="button"
+          className="font-bold text-2xl bg-lime-500 pr-10 pl-4 py-2 rounded-l-3xl text-white hidden lg:block lg:h-14 lg:self-center lg:col-start-11"
+        >
+          {'>'}
+        </button>
+        <div className="flex justify-between lg:hidden">
           <button
             onClick={() => paginate(currentPage - 1)}
             disabled={currentPage === 1}

--- a/src/components/pages/Login.jsx
+++ b/src/components/pages/Login.jsx
@@ -27,23 +27,29 @@ const Login = () => {
   };
 
   return (
-    <section className="flex flex-col items-center gap-6">
-      <h2 className="text-center text-xl font-bold">Login</h2>
+    <section className="flex flex-col items-center gap-8 m-4 lg:w-full lg:h-screen lg:mt-[20%]">
+      <h2 className="text-center text-2xl font-black uppercase mb-20">Login</h2>
 
-      <form onSubmit={handleSubmit}>
+      <form onSubmit={handleSubmit} className="flex flex-col text-xl">
         <label htmlFor="name-input">
           Name:
-          <input id="name-input" type="text" value={name} onChange={(e) => setName(e.target.value)} />
+          <input
+            id="name-input"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="border-2 border-black rounded-md ml-2 w-[70%]"
+          />
         </label>
         {formError && <p className="text-red-500">{formError}</p>}
-        <button type="submit">Login</button>
+        <button type="submit" className="border-2 border-lime-400 bg-lime-400 rounded px-4 py-2 w-32 self-center my-10">Login</button>
       </form>
 
-      <h4>
+      <h4 className="text-lg">
         Don&apos;t have an account yet?
-        {' '}
-        <Link to="/signup">Please sign-up</Link>
       </h4>
+
+      <Link to="/signup" className="cursor-pointer border-2 border-lime-400 bg-lime-400 rounded py-2 px-4 my-2">Please sign-up</Link>
     </section>
   );
 };

--- a/src/components/pages/Signup.jsx
+++ b/src/components/pages/Signup.jsx
@@ -27,16 +27,22 @@ const Signup = () => {
   };
 
   return (
-    <section className="flex flex-col items-center gap-6">
-      <h2 className="text-center text-xl font-bold">Sign up</h2>
+    <section className="flex flex-col items-center gap-8 m-4 lg:w-full lg:h-screen lg:mt-[20%]">
+      <h2 className="text-center text-2xl font-black uppercase mb-20">Sign up</h2>
 
-      <form onSubmit={handleSubmit}>
+      <form onSubmit={handleSubmit} className="flex flex-col text-xl">
         <label htmlFor="name-input">
           Name:
-          <input id="name-input" type="text" value={name} onChange={(e) => setName(e.target.value)} />
+          <input
+            id="name-input"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="border-2 border-black rounded-md ml-2 w-[70%]"
+          />
         </label>
         {formError && <p className="text-red-500">{formError}</p>}
-        <button type="submit">Sign up</button>
+        <button type="submit" className="border-2 border-lime-400 bg-lime-400 rounded px-4 py-2 w-32 self-center my-10">Sign up</button>
       </form>
     </section>
   );

--- a/src/redux/boats/boatsSlice.js
+++ b/src/redux/boats/boatsSlice.js
@@ -1,0 +1,42 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import axios from 'axios';
+
+const initialState = {
+  boats: [],
+  isLoading: false,
+  errors: null,
+};
+
+export const fetchBoats = createAsyncThunk('boats/fetchBoats', async () => {
+  try {
+    const response = await axios.get('http://localhost:3001/api/v1/boats');
+    console.log(response.data.data);
+    return response.data.data;
+  } catch (error) {
+    return error.response.data;
+  }
+});
+
+const boatsSlice = createSlice({
+  name: 'boats',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchBoats.pending, (state) => {
+        state.isLoading = true;
+      })
+      .addCase(fetchBoats.fulfilled, (state, action) => {
+        state.isLoading = false;
+        state.boats = action.payload;
+      })
+      .addCase(fetchBoats.rejected, (state, action) => {
+        state.isLoading = false;
+        state.errors = action.payload;
+      });
+  },
+});
+
+export default boatsSlice.reducer;
+
+export const selectAllBoats = (state) => state.boats.boats;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,9 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit';
 import usersessionReducer from './usersession/usersessionsSlice';
+import boatsReducer from './boats/boatsSlice';
 
 const store = configureStore({
   reducer: {
     usersession: usersessionReducer,
+    boats: boatsReducer,
   },
 });
 


### PR DESCRIPTION
## Create Main Boats section, Style Boats, Login and Signup

In this PR, I:

* Created the boatsSlice and added the API call, added reducer to store
* Created the main Boats page layout with styles according to the design, it contains the list of all boats in the database
* Styles include mobile and desktop version
* Updated main route, to navigate to the Boats page
* Updated styles for Uppercase where it was missing
* Added styles for the Login and Signup pages

Mobile version:

![Screenshot from 2023-12-12 17-09-36](https://github.com/Felipe-Perez-Ferraro/final_capstone_front/assets/101429702/a2bc3419-57b8-48b4-8fc0-22deed487157)


Desktop version:

![Screenshot from 2023-12-12 17-38-12](https://github.com/Felipe-Perez-Ferraro/final_capstone_front/assets/101429702/6fde9831-d6ae-4654-ab66-fb77ade68f9c)

![Screenshot from 2023-12-12 17-38-18](https://github.com/Felipe-Perez-Ferraro/final_capstone_front/assets/101429702/7588e552-10b8-49b7-8d00-246b9dad80e5)
